### PR TITLE
feat: configure Docker containerization for Hugging Face Spaces deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.github
+.dockerignore
+Dockerfile
+.venv
+venv
+*.pyc
+__pycache__
+db.sqlite3
+mediafiles/
+staticfiles/
+.env
+.env.local
+.docs
+.agents
+.pytest_cache
+.ruff_cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM python:3.13-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PORT=7860
+
+WORKDIR /app
+
+# Install system dependencies (e.g. gettext for translating messages)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gettext \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv globally
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+# Copy dependencies and install them system-wide
+COPY requirements.txt ./
+RUN uv pip install --system -r requirements.txt
+
+# Create a non-root user with UID 1000
+RUN useradd -m -u 1000 appuser
+
+# Copy project files and set ownership
+COPY --chown=appuser:appuser . .
+
+# Switch to the non-root user
+USER appuser
+
+# Expose port 7860
+EXPOSE 7860
+
+# Execute startup script
+CMD ["./start.sh"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+---
+title: Ceramic Shop
+emoji: 🏺
+colorFrom: red
+colorTo: yellow
+sdk: docker
+app_port: 7860
+---
+
 # Laura Melissa Ceramics – Full-Stack Django E-Commerce
 
 **Full-Stack Django Project · Freelancer Simulation**

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -o errexit
-uv sync --frozen
-uv run manage.py compilemessages
-uv run manage.py collectstatic --no-input
-uv run manage.py migrate --no-input

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -o errexit
+
+echo "==> Compiling translation messages..."
+python manage.py compilemessages
+
+echo "==> Collecting static files..."
+python manage.py collectstatic --no-input
+
+echo "==> Running database migrations..."
+python manage.py migrate --no-input
+
+echo "==> Starting Gunicorn server..."
+exec gunicorn main.wsgi:application --bind 0.0.0.0:7860


### PR DESCRIPTION
# Overview

This PR prepares and configures the Django application for Docker-based deployment on Hugging Face Spaces. It sets up the container configuration, startup orchestration, and deployment metadata.

## Key Changes
1. **Hugging Face Spaces Metadata**:
   - Added YAML metadata to the top of [README.md](file:///Users/juan/Documents/ceramic-shop/README.md) declaring `sdk: docker` and binding traffic to port `7860`.

2. **Containerization Configurations**:
   - Created a single-stage [Dockerfile](file:///Users/juan/Documents/ceramic-shop/Dockerfile) based on `python:3.13-slim` that installs dependencies system-wide using `uv` and runs the application under a secure non-root `appuser` (UID `1000`).
   - Created a [.dockerignore](file:///Users/juan/Documents/ceramic-shop/.dockerignore) file to exclude local virtual environments, SQLite databases, and build caches.

3. **Runtime & Server Orchestration**:
   - Created [start.sh](file:///Users/juan/Documents/ceramic-shop/start.sh) to handle startup operations (compiling translations, collecting static assets, running database migrations) and starting the Gunicorn server.
   - Removed the obsolete and redundant [build.sh](file:///Users/juan/Documents/ceramic-shop/build.sh) script, as its responsibilities are now fully managed by `start.sh` inside the container.

## Verification
- Verified that the Docker image builds successfully locally:
  ```bash
  docker build -t ceramic-shop .
  ```
- Executed full test suite via Git pre-push hook:
  ```bash
  uv run manage.py test
  ```
  **Result:** `Ran 50 tests in 4.905s. OK.`
